### PR TITLE
server:start event is now server.start. Removed number of fetched posts limit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ function bulkIndex(events, config, urlUtils){
   // Emitted in ghost-server.js
   events.on('server.start', function(){
     client.findOne({slug: 'ghost-frontend'}, {context: {internal: true}})
-    // .then((client) => getContent(urlUtils.urlFor('api', true) + 'posts/?formats=mobiledoc&client_id=ghost-frontend&client_secret=' + client.attributes.secret))
     .then((client) => getContent(urlUtils.urlFor('api', true) + 'posts/?formats=mobiledoc&limit=all&client_id=ghost-frontend&client_secret=' + client.attributes.secret))
     .then((data) => {
       let posts = JSON.parse(data).posts;

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ function bulkIndex(events, config, urlUtils){
   // Emitted in ghost-server.js
   events.on('server.start', function(){
     client.findOne({slug: 'ghost-frontend'}, {context: {internal: true}})
-    .then((client) => getContent(urlUtils.urlFor('api', true) + 'posts/?formats=mobiledoc&client_id=ghost-frontend&client_secret=' + client.attributes.secret))
+    // .then((client) => getContent(urlUtils.urlFor('api', true) + 'posts/?formats=mobiledoc&client_id=ghost-frontend&client_secret=' + client.attributes.secret))
+    .then((client) => getContent(urlUtils.urlFor('api', true) + 'posts/?formats=mobiledoc&limit=all&client_id=ghost-frontend&client_secret=' + client.attributes.secret))
     .then((data) => {
       let posts = JSON.parse(data).posts;
       if(posts.length > 0) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const GhostAlgolia = {
 function bulkIndex(events, config, urlUtils){
 
   // Emitted in ghost-server.js
-  events.on('server:start', function(){
+  events.on('server.start', function(){
     client.findOne({slug: 'ghost-frontend'}, {context: {internal: true}})
     .then((client) => getContent(urlUtils.urlFor('api', true) + 'posts/?formats=mobiledoc&client_id=ghost-frontend&client_secret=' + client.attributes.secret))
     .then((data) => {


### PR DESCRIPTION
Tested with ghost v1.22.4 and the event is emitted as `server.start` instead of `server:start`.